### PR TITLE
Simply graph logic

### DIFF
--- a/src/messages/graph_view.rs
+++ b/src/messages/graph_view.rs
@@ -3,14 +3,12 @@ use dtchat_backend::message::{ChatMessage, MessageStatus};
 use dtchat_backend::time::DTChatTime;
 use egui::Color32;
 use egui_plot::{AxisHints, BoxElem, BoxPlot, BoxSpread, GridMark, Legend, Plot, VLine};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::ops::RangeInclusive;
 #[derive(Clone)]
 pub struct MessageGraphView {
     auto_bounds: bool,
     show_current_time: bool,
-    active_participants: HashMap<String, String>,
-    filtered_participants: HashSet<String>,
     hovered: bool,
 }
 #[allow(dead_code)]
@@ -27,51 +25,58 @@ impl AutoReset for Plot<'_> {
     }
 }
 
+trait AsIndex {
+    fn as_index(&self) -> usize;
+}
+
+impl AsIndex for MessageStatus {
+    fn as_index(&self) -> usize {
+        match self {
+            MessageStatus::Sending => 0,
+            MessageStatus::Sent => 1,
+            MessageStatus::ReceivedByPeer => 2,
+            MessageStatus::Failed => 3,
+            MessageStatus::Received => 4,
+        }
+    }
+}
+
+fn get_bounds_for_box(message: &ChatMessage, now: f64) -> (f64, f64, f64, f64, f64) {
+
+    let sending = message.send_time.timestamp_millis() as f64;
+    let mut med = sending;
+    let mut sent = match message.send_completed {
+        Some(val) => val.timestamp_millis() as f64,
+        None => now,
+    };
+    let recv = match message.receive_time {
+        Some(val) => val.timestamp_millis() as f64,
+        None => now,
+    };
+    let pred = match message.predicted_arrival_time {
+        Some(val) => {
+                let p = val.timestamp_millis() as f64;
+                med = p;
+                p
+        },
+        None => recv
+    };
+
+    // For visibility
+    if message.status == MessageStatus::Failed {
+        sent = sending;
+    }
+
+    (sending, sent, med, recv, pred)
+}
+
 impl MessageGraphView {
     pub fn new() -> Self {
         Self {
             auto_bounds: true,
             show_current_time: true,
-            active_participants: HashMap::new(),
-            filtered_participants: HashSet::new(),
             hovered: false,
         }
-    }
-
-    fn update_participants(
-        &mut self,
-        messages: &[ChatMessage],
-        peers: &HashMap<String, Peer>,
-        local_peer_uuid: &str,
-    ) {
-        self.active_participants.clear();
-
-        // Collect all unique sender UUIDs from messages
-        let mut sender_uuids: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for message in messages {
-            sender_uuids.insert(message.sender_uuid.clone());
-        }
-
-        // Add local peer if not already present
-        sender_uuids.insert(local_peer_uuid.to_string());
-
-        // Process all participants at once
-        for uuid in sender_uuids {
-            let name = if uuid == local_peer_uuid {
-                "Me".to_string()
-            } else {
-                if let Some(p) = peers.get(&uuid) {
-                    p.name.clone()
-                } else {
-                    "??".to_string()
-                }
-            };
-            self.active_participants.insert(uuid, name);
-        }
-    }
-
-    fn should_show_message(&self, message: &ChatMessage) -> bool {
-        !self.filtered_participants.contains(&message.sender_uuid)
     }
 
     fn create_box_element(
@@ -79,93 +84,19 @@ impl MessageGraphView {
         message: &ChatMessage,
         y_position: f64,
         now: f64,
-    ) -> (BoxElem, String, Color32, String, f64, f64) {
+    ) -> (BoxElem, f64, f64) {
         // Nom de la boîte simplifié sans emoji
         let box_name = self.truncate_text(&message.content_as_string(), 30);
 
-        // Statut du message pour la tooltip
-        let status_text = match &message.status {
-            MessageStatus::Failed => "FAILED",
-            MessageStatus::ReceivedByPeer => "ACKED",
-            MessageStatus::Sent => "SENT",
-            MessageStatus::Sending => "SENDING",
-            MessageStatus::Received => "RECEIVED",
-        }
-        .to_string();
-
-        // Couleur selon le statut du message
-        let status_color = match &message.status {
-            MessageStatus::Failed => Color32::RED,
-            MessageStatus::ReceivedByPeer => Color32::GREEN,
-            MessageStatus::Sent => Color32::LIGHT_GRAY,
-            MessageStatus::Sending => Color32::YELLOW,
-            MessageStatus::Received => Color32::LIGHT_BLUE,
-        };
-
-        let (sent, pbat, recv) = message.get_shipment_status_timestamps();
-        // Calcul de l'étendue de la boîte selon l'état du message
-        let (start_time, end_time) = match &message.status {
-            MessageStatus::ReceivedByPeer => {
-                // let mut send_time = tx;
-                // // ACK reçu - largeur = délai réel
-                // let receive_time = message
-                //     .receive_time
-                //     .map(|t| {
-                //         send_time -= 500.0;
-                //         t.timestamp_millis() as f64
-                //     })
-                //     .unwrap_or(tx + 500.0);
-                // (send_time, receive_time)
-                let recv_opt = {
-                    if let Some(val) = recv {
-                        val as f64
-                    } else {
-                        sent as f64
-                    }
-                };
-                (sent as f64, recv_opt as f64)
-            }
-            MessageStatus::Received => {
-                let recv_opt = {
-                    if let Some(val) = recv {
-                        val as f64
-                    } else {
-                        sent as f64
-                    }
-                };
-                (sent as f64, recv_opt as f64)
-            }
-            MessageStatus::Failed => {
-                // Message échoué - boîte très courte, animation arrêtée
-                ((sent - 50) as f64, (sent + 50) as f64)
-            }
-            MessageStatus::Sent | MessageStatus::Sending => {
-                // Pas d'ACK encore - animer la boîte
-                let recv_opt = {
-                    if let Some(val) = pbat {
-                        val as f64
-                    } else {
-                        now
-                    }
-                };
-                (sent as f64, recv_opt)
-            }
-        };
+        let (sending, sent, med, recv, pred) = get_bounds_for_box(message, now);
 
         let box_elem = BoxElem::new(
             y_position,
-            BoxSpread::new(start_time, start_time, start_time, end_time, end_time),
+            BoxSpread::new(sending, sent, med, recv, pred),
         )
         .name(box_name);
 
-        (
-            box_elem,
-            message.sender_uuid.clone(),
-            status_color,
-            status_text,
-            start_time,
-            end_time,
-        )
+        (box_elem, sending, pred)
     }
 
     fn truncate_text(&self, text: &str, max_length: usize) -> String {
@@ -204,8 +135,6 @@ impl MessageGraphView {
         let now = current_time.timestamp_millis() as f64;
         let peers = &other_peers;
 
-        self.update_participants(messages, peers, &local_peer.uuid);
-
         ui.horizontal(|ui| {
             ui.checkbox(&mut self.auto_bounds, "Auto_bounds");
         });
@@ -219,18 +148,14 @@ impl MessageGraphView {
             }
         });
 
-        let filtered_messages: Vec<&ChatMessage> = messages
-            .iter()
-            .filter(|msg| self.should_show_message(msg))
-            .collect();
+        // we try to find some bounds
         let mut first_message = now;
         let mut last_message = now;
-        // Group messages by sender
-        let mut boxes_by_participant: HashMap<String, Vec<(BoxElem, Color32, String)>> =
+        // Group messages by sender and status (status converted to index)
+        let mut boxes_by_participant: HashMap<(String, usize), (MessageStatus, Vec<BoxElem>)> =
             HashMap::new();
-        for (index, message) in filtered_messages.iter().enumerate() {
-            let (box_elem, sender_uuid, status_color, status_text, from, to) =
-                self.create_box_element(message, index as f64, now);
+        for (index, message) in messages.iter().enumerate() {
+            let (box_elem, from, to) = self.create_box_element(message, index as f64, now);
             if from < first_message {
                 first_message = from;
             }
@@ -239,15 +164,16 @@ impl MessageGraphView {
             }
 
             boxes_by_participant
-                .entry(sender_uuid)
-                .or_insert(Vec::new())
-                .push((box_elem, status_color, status_text));
+                .entry((message.sender_uuid.clone(), message.status.as_index()))
+                .or_insert((message.status.clone(), Vec::new()))
+                .1
+                .push(box_elem);
         }
 
-        let num_messages = if filtered_messages.is_empty() {
+        let num_messages = if messages.is_empty() {
             1.0
         } else {
-            filtered_messages.len() as f64
+            messages.len() as f64
         };
         let plot_height = ui.available_height().max(300.0);
 
@@ -262,8 +188,6 @@ impl MessageGraphView {
             .include_x(last_message + (last_message - first_message) * 0.2)
             .custom_x_axes(x_axes)
             .custom_y_axes(vec![])
-            // .auto_reset(reset_requested)
-            // .auto_bounds(self.auto_bounds)
             .label_formatter(|name, value| {
                 if !name.is_empty() {
                     format!("{}: {:.*}%", name, 1, value.y)
@@ -279,79 +203,68 @@ impl MessageGraphView {
                     plot_ui.vline(VLine::new(now).color(Color32::RED).name("Current Time"));
                 }
 
-                for (participant_uuid, boxes_with_colors) in &boxes_by_participant {
-                    if let Some(participant_name) = self.active_participants.get(participant_uuid) {
-                        let formatter_name = participant_name.clone();
-
-                        // Séparer les boîtes par couleur de statut
-                        let mut boxes_by_status: HashMap<Color32, Vec<(BoxElem, String)>> =
-                            HashMap::new();
-                        for (box_elem, status_color, status_text) in boxes_with_colors {
-                            boxes_by_status
-                                .entry(*status_color)
-                                .or_insert(Vec::new())
-                                .push((box_elem.clone(), status_text.clone()));
+                for ((participant_uuid, _status_as_index), (status, boxes_with_colors)) in
+                    boxes_by_participant
+                {
+                    let participant_name = if local_peer.uuid == *participant_uuid {
+                        "Me".to_string()
+                    } else {
+                        match peers.get(&participant_uuid) {
+                            Some(p) => p.name.clone(),
+                            None => "unknown".to_string(),
                         }
+                    };
 
-                        // Créer un BoxPlot pour chaque couleur de statut
-                        for (status_color, boxes_with_status) in boxes_by_status {
-                            let status_name = match status_color {
-                                Color32::RED => format!("{} (FAILED)", participant_name),
-                                Color32::GREEN => format!("{} (ACKED)", participant_name),
-                                Color32::YELLOW => format!("{} (SENDING)", participant_name),
-                                Color32::LIGHT_BLUE => format!("{} (RECEIVED)", participant_name),
-                                _ => format!("{} (SENT)", participant_name),
-                            };
+                    let formatter_name = participant_name.clone();
 
-                            // Extraire les BoxElem et garder les statuts pour la tooltip
-                            let boxes: Vec<BoxElem> = boxes_with_status
-                                .iter()
-                                .map(|(box_elem, _)| box_elem.clone())
-                                .collect();
-                            let statuses: Vec<String> = boxes_with_status
-                                .iter()
-                                .map(|(_, status)| status.clone())
-                                .collect();
-
-                            // Cloner formatter_name pour l'utiliser dans la closure
-                            let formatter_name_for_closure = formatter_name.clone();
-
-                            let box_plot = BoxPlot::new(boxes)
-                                .name(status_name)
-                                .color(status_color)
-                                .horizontal()
-                                .allow_hover(true)
-                                .element_formatter(Box::new(move |bar, _bar_chart| {
-                                    let tx_time = DTChatTime::from_timestamp_millis(
-                                        bar.spread.quartile1 as i64,
-                                    )
-                                    .unwrap();
-                                    let rx_time = DTChatTime::from_timestamp_millis(
-                                        bar.spread.quartile3 as i64,
-                                    )
-                                    .unwrap();
-                                    let date = tx_time.date_naive() != rx_time.date_naive();
-
-                                    // Essayer de récupérer le statut correspondant (approximation basée sur l'index)
-                                    let status_info = if !statuses.is_empty() {
-                                        format!("\nStatus: {}", &statuses[0]) // Utilise le premier statut de ce groupe
-                                    } else {
-                                        "".to_string()
-                                    };
-
-                                    format!(
-                                        "Message: {}\nSent by {}\ntx time: {}\nrx_time: {}{}",
-                                        bar.name,
-                                        formatter_name_for_closure,
-                                        tx_time.ts_to_str(date, true, None, &chrono::Local),
-                                        rx_time.ts_to_str(date, true, None, &chrono::Local),
-                                        status_info
-                                    )
-                                }));
-
-                            plot_ui.box_plot(box_plot);
-                        }
+                    // Legend text
+                    let status_text = match status {
+                        MessageStatus::Failed => format!("{} (FAILED)", participant_name),
+                        MessageStatus::ReceivedByPeer => format!("{} (ACKED)", participant_name),
+                        MessageStatus::Sending => format!("{} (SENDING)", participant_name),
+                        MessageStatus::Received => format!("{} (RECEIVED)", participant_name),
+                        MessageStatus::Sent => format!("{} (SENT)", participant_name),
                     }
+                    .to_string();
+
+                    let status_color = match status {
+                        MessageStatus::Failed => Color32::RED,
+                        MessageStatus::ReceivedByPeer => Color32::GREEN,
+                        MessageStatus::Sent => Color32::LIGHT_GRAY,
+                        MessageStatus::Sending => Color32::YELLOW,
+                        MessageStatus::Received => Color32::LIGHT_BLUE,
+                    };
+
+                    let box_plot = BoxPlot::new(boxes_with_colors)
+                        .name(status_text.clone())
+                        .color(status_color)
+                        .horizontal()
+                        .allow_hover(true)
+                        .element_formatter(Box::new(move |bar, _bar_chart| {
+                            let tx_time =
+                                DTChatTime::from_timestamp_millis(bar.spread.quartile1 as i64)
+                                    .unwrap();
+                            let rx_time =
+                                DTChatTime::from_timestamp_millis(bar.spread.quartile3 as i64)
+                                    .unwrap();
+                            let date = tx_time.date_naive() != rx_time.date_naive();
+
+                            // Essayer de récupérer le statut correspondant (approximation basée sur l'index)
+                            let status_info =
+                                        format!("\nStatus: {}", status_text) // Utilise le premier statut de ce groupe
+                            ;
+
+                            format!(
+                                "Message: {}\nSent by {}\ntx time: {}\nrx_time: {}{}",
+                                bar.name,
+                                formatter_name,
+                                tx_time.ts_to_str(date, true, None, &chrono::Local),
+                                rx_time.ts_to_str(date, true, None, &chrono::Local),
+                                status_info
+                            )
+                        }));
+
+                    plot_ui.box_plot(box_plot);
                 }
             });
         self.hovered = plt.response.hovered();


### PR DESCRIPTION
Box bounds are now calculated in a simplified manner, add a first quartile whisker for sending.
Boxes are not gathered by group (participant/status) in a single round, rather than 2+.
Logic for filtering removed, each message view (graph/list) shall expect a filtered input. The logic did not have any effect anyway.
Duplication of status/color pattern matching removed.
Remove/translate French comments.
BoxElem could be saved (BoxPlot is not clonable) rather than calculated at each frame, this is for the moment future work as long as the BoxElem can slightly change at each frame (when a bound is equal to current time)
